### PR TITLE
Spawn vim from program without breaking terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use regex::Regex;
 use std::io::stdin;
 use libc::*;
 use std::ffi::CString;
+use std::process::{Command, Stdio};
+use std::fs::File;
 
 const REGULAR_PAIR: i16 = 1;
 const CURSOR_PAIR: i16 = 2;
@@ -54,7 +56,15 @@ fn main() -> Result<(), String> {
                 for cap in re.captures_iter(lines[cursor].as_str()) {
                     // TODO(#4): cm does not run the program
                     //   https://www.reddit.com/r/rust/comments/917kcq/using_stdprocesscommand_to_open_file_in_vi/
-                    println!("vim +{} {}", &cap[2], &cap[1]);
+                    //println!("vim +{} {}", &cap[2], &cap[1]);
+                    Command::new("vim")
+                        .stdin(File::open("/dev/tty").unwrap())
+                        .arg(format!("+{}", &cap[2]))
+                        .arg(&cap[1])
+                        .spawn()
+                        .expect("Something went wrong.")
+                        .wait_with_output()
+                        .expect("Something went wrong");
                 }
                 return Ok(());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::io::stdin;
 use libc::*;
 use std::ffi::CString;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::fs::File;
 
 const REGULAR_PAIR: i16 = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), String> {
             10 => {
                 endwin();
                 for cap in re.captures_iter(lines[cursor].as_str()) {
-                    // TODO: the program does not go back after exiting vim
+                    // TODO(#6): the program does not go back after exiting vim
                     Command::new("vim")
                         .stdin(File::open("/dev/tty").unwrap())
                         .arg(format!("+{}", &cap[2]))

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,10 +61,8 @@ fn main() -> Result<(), String> {
                         .stdin(File::open("/dev/tty").unwrap())
                         .arg(format!("+{}", &cap[2]))
                         .arg(&cap[1])
-                        .spawn()
-                        .expect("Something went wrong.")
-                        .wait_with_output()
-                        .expect("Something went wrong");
+                        .spawn().map_err(|e| e.to_string())?
+                        .wait_with_output().map_err(|e| e.to_string())? ;
                 }
                 return Ok(());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,7 @@ fn main() -> Result<(), String> {
             10 => {
                 endwin();
                 for cap in re.captures_iter(lines[cursor].as_str()) {
-                    // TODO(#4): cm does not run the program
-                    //   https://www.reddit.com/r/rust/comments/917kcq/using_stdprocesscommand_to_open_file_in_vi/
-                    //println!("vim +{} {}", &cap[2], &cap[1]);
+                    // TODO: the program does not go back after exiting vim
                     Command::new("vim")
                         .stdin(File::open("/dev/tty").unwrap())
                         .arg(format!("+{}", &cap[2]))


### PR DESCRIPTION
Vim now spawns correctly, there is no more `Input not a terminal` thingy... currently it does not return to program, not sure if intended or not since right now vim and program are sharing `/dev/tty`

Closes #4 