### PR TITLE
Use system-specified editor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ impl Default for Profile {
                 cursor_y: 0,
             },
             cmd_list: ItemList::<String> {
-                items: vec!["vim +\\2 \\1".to_string()],
+                items: vec!["$EDITOR +\\2 \\1".to_string()],
                 cursor_x: 0,
                 cursor_y: 0
             },


### PR DESCRIPTION
Now using $EDITOR instead of defaulting to vim.

This won't work on windows and stuff, though I don't think that's a priority.