### PR TITLE
(#77) Add example of fixing compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ $ grep -rn 'String' src/ | cargo run
 ```
 
 [compilation-mode]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html
+
+## Examples
+
+**Fixing compilation errors**
+[![asciicast](https://asciinema.org/a/337846.svg)](https://asciinema.org/a/337846)


### PR DESCRIPTION
This PR adds link to asciinema in README, showing how cm can be used to fix compilation errors in small C program.

This is the mentioned link: <https://asciinema.org/a/337846>.

This should be linked to the issue #77.