### PR TITLE
Use rustfmt builtin functionality instead of separate diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,4 @@ jobs:
           command: clippy
       - uses: actions-rs/cargo@v1
         with:
-          command: fmt
-      - name: check fmt
-        run: |
-          git diff --exit-code
+          command: fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
           command: clippy
       - uses: actions-rs/cargo@v1
         with:
-          command: fmt -- --check
+          command: fmt
+          args: -- --check


### PR DESCRIPTION
There is no need to use diff if we can use rustfmt's builtin functionality.