### PR TITLE
Capture absolute paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -387,7 +387,7 @@ impl Profile {
             .regex_list
             .list
             .items
-            .push(r"\b(.*?):(\d+):".to_string());
+            .push(r"(\/?\b.*?):(\d+):".to_string());
         result.cmd_list.list.items.push("vim +\\2 \\1".to_string());
         result
             .cmd_list


### PR DESCRIPTION
Current default regex doesn't capture `/` from beginning of path
