### PR TITLE
Update regex

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ impl Profile {
             .regex_list
             .list
             .items
-            .push(r"([^[:space:]]+\b.*?):(\d+):".to_string());
+            .push(r"([^[:space:]]*\b.*?):(\d+):".to_string());
         result.cmd_list.list.items.push("vim +\\2 \\1".to_string());
         result
             .cmd_list

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ impl Profile {
             .regex_list
             .list
             .items
-            .push(r"(\/?\b.*?):(\d+):".to_string());
+            .push(r"([^[:space:]]+\b.*?):(\d+):".to_string());
         result.cmd_list.list.items.push("vim +\\2 \\1".to_string());
         result
             .cmd_list


### PR DESCRIPTION
Previous change fixed issue with `/`
But same issue is also with paths that begins with
* parent `../` 
* hidden files `.`
* utf8 (requires #61)
* relative `./`
* emoji (requires #61)

Tests on current regex: https://regexr.com/583te
Tests on new regex: https://regexr.com/583t8

Instead of trying to capture every unicode character regex assumes that path doesn't begin with any character in `[:space:]` and doesn't only contain unicode characters

After messing around this could be possible solution
`([^[:space:]]*(?:(?<![0-9A-zÀ-𪘀])(?=[0-9A-zÀ-𪘀])|(?<=[0-9A-zÀ-𪘀])(?![0-9A-zÀ-𪘀])).*?):(\d+):` 
Shortened `((?=[0-9A-Za-zÀ-𪘀.\/]).*?):(\d+):`
Adapted from [https://stackoverflow.com/a/14942652/how-to-emulate-word-boundary-when-using-unicode-character-properties](https://stackoverflow.com/a/14942652/DO-YOU-KNOW-REGEX)
But does not work in cm as it gets cut off ¯\_(ツ)_/¯
