### PR TITLE
Update regex

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ impl Profile {
             .regex_list
             .list
             .items
-            .push(r"(\/?\b.*?):(\d+):".to_string());
+            .push(r"([\/.]*[_0-9A-Za-zÀ-𪘀].*?):(\d+):".to_string());
         result.cmd_list.list.items.push("vim +\\2 \\1".to_string());
         result
             .cmd_list


### PR DESCRIPTION
Updated version which fixes issues mentioned in (#111)

Word boundary doesn't check for utf8
So instead only allow paths to begin with a set of characters
This way path can contain utf8 characters everywhere

Tests on current regex: https://regexr.com/583te
Tests on mew regex:: [regexr.com/585ij](https://regexr.com/585ij)
Copy paste regex since site has issue with that utf8 character
`([\/.]*[_0-9A-Za-zÀ-𪘀].*?):(\d+):`