### PR TITLE
Make cm handle tab characters within output strings better

### DIFF
--- a/src/cm/output_buffer.rs
+++ b/src/cm/output_buffer.rs
@@ -293,3 +293,39 @@ impl OutputBuffer {
         }
     }
 }
+
+/// Expands tab ('\t' 0x9) characters within an input string
+/// into a variable amount of spaces.
+///
+/// ```text
+/// |--------|    |--------|--------| 8 spaces/tab (tabsize = 8)
+/// |\t      | => |........|        | 8 spaces
+/// |\ta     | => |........|a       | 8 spaces + "a"
+/// |aaa\t   | => |aaa.....|        | "aaa" + 5 spaces
+/// ```
+///
+fn expand_tabs(input: &str, tabsize: usize) -> String {
+    if tabsize == 0 {
+        return input.replace('\t', "");
+    }
+    if tabsize == 1 {
+        return input.replace('\t', " ");
+    }
+
+    let mut result =
+        String::with_capacity(input.len() + (tabsize - 1) * input.matches('\t').count());
+    let mut char_count = 0;
+
+    for c in input.chars() {
+        if c == '\t' {
+            let space_count = tabsize - (char_count % tabsize);
+            char_count += space_count;
+            result.extend(std::iter::repeat(' ').take(space_count));
+        } else {
+            char_count += 1;
+            result.push(c);
+        }
+    }
+
+    result
+}

--- a/src/cm/output_buffer.rs
+++ b/src/cm/output_buffer.rs
@@ -211,7 +211,7 @@ impl OutputBuffer {
                     Ok(0) => break,
                     Ok(_) => {
                         if let Some(list) = self.lists.last_mut() {
-                            list.items.push(line.clone());
+                            list.items.push(expand_tabs(&line, TABSIZE() as usize));
                             changed = true;
                         }
                     }

--- a/src/cm/output_buffer.rs
+++ b/src/cm/output_buffer.rs
@@ -211,6 +211,7 @@ impl OutputBuffer {
                     Ok(0) => break,
                     Ok(_) => {
                         if let Some(list) = self.lists.last_mut() {
+                            // TODO(#185): move the tab expansion to ItemList so it's available for every list-like component
                             list.items.push(expand_tabs(&line, TABSIZE() as usize));
                             changed = true;
                         }


### PR DESCRIPTION
Hello. I've noticed a couple of problems with strings that contain tab (`\t`) characters:

- Text jumps during horizontal scrolling:

![horizontal-scroll](https://user-images.githubusercontent.com/34111964/92546738-afea9e80-f26c-11ea-9ab0-53af04a27034.gif)

In this case, string is `"..\taa\tbb"`

- Match highlight is off:

![cm-git-status-highlight-mismatch](https://user-images.githubusercontent.com/34111964/92596060-a12cd780-f2be-11ea-98f8-839c497a0e31.gif)

This happens because highlighting is done using a byte offset of a match and `\t` is a single byte with a display width of 8, so highlight is off by 7 characters.

---

Solution, in this PR, is to expand tabs into spaces when collecting output from a child process. Applied, solves both problems:

![horizontal-scroll-fixed](https://user-images.githubusercontent.com/34111964/92546741-b11bcb80-f26c-11ea-8002-5924e3694626.gif)

![cm-git-status-highlight-fixed](https://user-images.githubusercontent.com/34111964/92596054-9ffbaa80-f2be-11ea-8ae3-b20785feed05.gif)