### PR TITLE
Fix truncation of configuration values

### DIFF
--- a/src/cm/profile.rs
+++ b/src/cm/profile.rs
@@ -28,15 +28,22 @@ impl Profile {
             let fail = |message| panic!("{}:{}: {}", file_path.display(), i + 1, message);
 
             if !line.is_empty() {
-                let mut assign = line.split('=');
-                let key = assign
-                    .next()
-                    .unwrap_or_else(|| fail("Key is not provided"))
-                    .trim();
-                let value = assign
-                    .next()
-                    .unwrap_or_else(|| fail("Value is not provided"))
-                    .trim();
+                let (key, value) = line
+                    .find('=')
+                    .map(|pos| {
+                        let (lh, rh) = line.split_at(pos);
+                        (lh.trim(), rh[1..].trim())
+                    })
+                    .unwrap_or_else(|| fail("Invalid configuration line"));
+
+                if key.is_empty() {
+                    fail("Key is not provided");
+                }
+
+                if value.is_empty() {
+                    fail("Value is not provided");
+                }
+
                 match key {
                     "regexs" => {
                         regex_count += 1;

--- a/src/cm/profile.rs
+++ b/src/cm/profile.rs
@@ -40,10 +40,6 @@ impl Profile {
                     fail("Key is not provided");
                 }
 
-                if value.is_empty() {
-                    fail("Value is not provided");
-                }
-
                 match key {
                     "regexs" => {
                         regex_count += 1;
@@ -54,6 +50,9 @@ impl Profile {
                         result.cmd_list.list.items.push(value.to_string());
                     }
                     "current_regex" => {
+                        if value.is_empty() {
+                            fail("Value is not provided");
+                        }
                         result.regex_list.list.cursor_y =
                             value.parse::<usize>().unwrap_or_else(|_| {
                                 fail("Not a number");
@@ -61,6 +60,9 @@ impl Profile {
                             })
                     }
                     "current_cmd" => {
+                        if value.is_empty() {
+                            fail("Value is not provided");
+                        }
                         result.cmd_list.list.cursor_y =
                             value.parse::<usize>().unwrap_or_else(|_| {
                                 fail("Not a number");
@@ -68,6 +70,9 @@ impl Profile {
                             })
                     }
                     key => {
+                        if value.is_empty() {
+                            fail("Value is not provided");
+                        }
                         let key_stroke = KeyStroke::from_str(key).unwrap();
                         let action = action::from_str(value).unwrap();
                         result.key_map.bind(key_stroke, action);


### PR DESCRIPTION
Values which contained equals character were truncated at that character. So a configuration line like:
```
key = value=equals
```
was read and loaded like:
```
key = value
```
This was happening because lines were split on '=' using an iterator which was stopping at second equals, so the rest of the value wasn't being read.

Empty values for commands and regexes are allowed because otherwise it is very easy to break config just by saving an empty command or regex from within `cm`.