### PR TITLE
(#21) catch_unwind the whole app

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ fn render_cmdline(line: &str, cmd: &str, regex: &Regex) -> Option<String> {
 }
 
 fn start_cm() {
+    ctrlc::init();
+
     // NOTE(timeout): timeout(16) is a very important setting of ncurses for our
     // application. It makes getch() asynchronous, which is essential
     // for non-blocking UI when receiving the output from the child
@@ -48,11 +50,6 @@ fn start_cm() {
     noecho();
     keypad(stdscr(), true);
     init_style();
-
-    ctrlc::init();
-
-    let locale_conf = LcCategory::all;
-    setlocale(locale_conf, "en_US.UTF-8");
 
     let config_path = {
         const CONFIG_FILE_NAME: &str = "cm.conf";
@@ -308,6 +305,9 @@ fn start_cm() {
 }
 
 fn main() {
+    let locale_conf = LcCategory::all;
+    setlocale(locale_conf, "en_US.UTF-8");
+
     initscr();
     let result = catch_unwind(start_cm);
     endwin();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use ncurses::*;
 use pcre2::bytes::{Regex, RegexBuilder};
 use std::env::var;
 use std::fs::{create_dir_all, File};
-use std::path::PathBuf;
 use std::panic::catch_unwind;
+use std::path::PathBuf;
 
 fn render_status(y: usize, text: &str) {
     attron(COLOR_PAIR(REGULAR_PAIR));

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use pcre2::bytes::{Regex, RegexBuilder};
 use std::env::var;
 use std::fs::{create_dir_all, File};
 use std::path::PathBuf;
+use std::panic::catch_unwind;
 
 fn render_status(y: usize, text: &str) {
     attron(COLOR_PAIR(REGULAR_PAIR));
@@ -308,7 +309,7 @@ fn start_cm() {
 
 fn main() {
     initscr();
-    let result = std::panic::catch_unwind(|| start_cm());
+    let result = catch_unwind(start_cm);
     endwin();
-    result.unwrap()
+    result.unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,23 @@ fn render_cmdline(line: &str, cmd: &str, regex: &Regex) -> Option<String> {
     })
 }
 
-fn main() {
+fn start_cm() {
+    // NOTE(timeout): timeout(16) is a very important setting of ncurses for our
+    // application. It makes getch() asynchronous, which is essential
+    // for non-blocking UI when receiving the output from the child
+    // process.
+    //
+    // The value of 16 milliseconds also blocks the application for a
+    // little. This improves the performance by making the application
+    // to not constantly busy loop on checking the input from the user
+    // and the running child process.
+    //
+    // 16 milliseconds were chosen to make the application "run in 60 fps" :D
+    timeout(16);
+    noecho();
+    keypad(stdscr(), true);
+    init_style();
+
     ctrlc::init();
 
     let locale_conf = LcCategory::all;
@@ -76,24 +92,6 @@ fn main() {
         let shell = profile.current_shell().unwrap();
         output_buffer.run_cmdline(cmdline, shell);
     }
-
-    initscr();
-    // NOTE(timeout): timeout(16) is a very important setting of ncurses for our
-    // application. It makes getch() asynchronous, which is essential
-    // for non-blocking UI when receiving the output from the child
-    // process.
-    //
-    // The value of 16 milliseconds also blocks the application for a
-    // little. This improves the performance by making the application
-    // to not constantly busy loop on checking the input from the user
-    // and the running child process.
-    //
-    // 16 milliseconds were chosen to make the application "run in 60 fps" :D
-    timeout(16);
-    noecho();
-    keypad(stdscr(), true);
-
-    init_style();
 
     // NOTE(rerender): because of the asynchronous nature of the application the
     // rendering process could be invoked every 16 millisecond (See NOTE(timeout)),
@@ -302,11 +300,15 @@ fn main() {
         rerender = false;
     }
 
-    // TODO(#21): if application crashes it does not finalize the terminal
-    endwin();
-
     config_path.parent().map(create_dir_all);
     profile
         .to_file(&mut File::create(config_path).expect("Could not open configuration file"))
         .expect("Could not save configuration");
+}
+
+fn main() {
+    initscr();
+    let result = std::panic::catch_unwind(|| start_cm());
+    endwin();
+    result.unwrap()
 }


### PR DESCRIPTION
Catch any unwind happening in the application and finalize the terminal before crashing and printing the error message.

Close #21 