### PR TITLE
Set-up a custom panic hook to finalize the terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use ncurses::*;
 use pcre2::bytes::{Regex, RegexBuilder};
 use std::env::var;
 use std::fs::{create_dir_all, File};
-use std::panic::catch_unwind;
+use std::panic::{set_hook, take_hook};
 use std::path::PathBuf;
 
 fn render_status(y: usize, text: &str) {
@@ -315,8 +315,15 @@ fn main() {
     let locale_conf = LcCategory::all;
     setlocale(locale_conf, "en_US.UTF-8");
 
+    set_hook(Box::new({
+        let default_hook = take_hook();
+        move |payload| {
+            endwin();
+            default_hook(payload);
+        }
+    }));
+
     initscr();
-    let result = catch_unwind(start_cm);
+    start_cm();
     endwin();
-    result.unwrap();
 }


### PR DESCRIPTION
Approach with catch_unwind makes us lose valuable panic information e.g. location of the panic/error, so instead of doing that lets set-up a custom panic hook which will finalize the terminal and execute a default panic hook which will print the panic message for us.