### PR TITLE
item_list: slightly improve #213 readability

### DIFF
--- a/src/cm/item_list.rs
+++ b/src/cm/item_list.rs
@@ -30,8 +30,10 @@ impl<T: ToString + Clone> ItemList<T> {
     }
 
     pub fn page_down(&mut self, page_size: usize) {
-        self.scroll_y = min(self.scroll_y + page_size, self.items.len() - 1);
-        self.cursor_y = min(self.scroll_y + page_size - 1, self.items.len() - 1);
+        if self.cursor_y < self.items.len() - 1 {
+            self.scroll_y = min(self.scroll_y + page_size, self.items.len() - 1);
+            self.cursor_y = min(self.scroll_y + page_size - 1, self.items.len() - 1);
+        }
     }
 
     pub fn up(&mut self) {


### PR DESCRIPTION
- prevent excessive scrolling: don't page-down when already at bottom of items_list

I noticed cm was paging down again when the cursor is on the last line, moving it to the top of the screen.  I think its slightly more readable to prevent this last page-down which hides all but the last line of text from view. 